### PR TITLE
fix: 'RGB_NUM' undeclared

### DIFF
--- a/rev1/config.h
+++ b/rev1/config.h
@@ -42,7 +42,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define WS2812_DI_PIN GP20
 #define RGBLED_NUM 24
 #define RGBLED_SPLIT {12, 12}
-#define RGBLIGHT_LED_COUNT RGB_NUM
+#define RGBLIGHT_LED_COUNT RGBLED_NUM
 
 /* serial.c configuration for split keyboard */
 //#define WS2812_PIO_USE_PIO1 // Force the usage of PIO1 peripheral, by default the WS2812 implementation uses the PIO0 peripheral


### PR DESCRIPTION
Before this change, I would receive this error:

```
./keyboards/neodox_ergomech/rev1/config.h:45:28: error: 'RGB_NUM' undeclared here (not in a function)
   45 | #define RGBLIGHT_LED_COUNT RGB_NUM
      |                            ^~~~~~~
```

I also had to make [this change](https://github.com/vial-kb/vial-qmk/compare/vial...zaz:vial-qmk:vial) to Vial to get this to compile.  I'd appreciate it if you'd submit that upstream if appropriate.

I don't know if this is the best way to go about fixing it, it was just a quick fix to get it working for me.